### PR TITLE
fix: correct blog link paths to use relative URLs

### DIFF
--- a/about.html
+++ b/about.html
@@ -21,7 +21,7 @@
 					<nav class="navbar">
 						<a href="index.html" class="navbar__link">Home</a>
 						<a href="#about" class="navbar__link">About</a>
-						<a href="/blogs.html" class="navbar__link">Blog</a>
+						<a href="blogs.html" class="navbar__link">Blog</a>
 					</nav>
 					<div class="header__actions">
 						<button class="button button__contact">Contact Us</button>
@@ -33,7 +33,7 @@
 						<div class="hamburger__menu">
 							<a href="index.html" class="hamburger__link">Home</a>
 							<a href="#about" class="hamburger__link">About</a>
-							<a href="/blogs.html" class="hamburger__link">Blog</a>
+							<a href="blogs.html" class="hamburger__link">Blog</a>
 						</div>
 					</div>
 				</div>

--- a/blogs.html
+++ b/blogs.html
@@ -34,7 +34,7 @@
 					<nav class="navbar">
 						<a href="index.html" class="navbar__link">Home</a>
 						<a href="about.html" class="navbar__link">About</a>
-						<a href="/blogs.html" class="navbar__link">Blog</a>
+						<a href="blogs.html" class="navbar__link">Blog</a>
 					</nav>
 					<div class="header__actions">
 						<button class="button button__contact">Contact Us</button>
@@ -46,7 +46,7 @@
 						<div class="hamburger__menu">
 							<a href="index.html" class="hamburger__link">Home</a>
 							<a href="about.html" class="hamburger__link">About</a>
-							<a href="/blogs.html" class="hamburger__link">Blog</a>
+							<a href="blogs.html" class="hamburger__link">Blog</a>
 						</div>
 					</div>
 				</div>

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
 					<nav class="navbar">
 						<a href="index.html" class="navbar__link">Home</a>
 						<a href="about.html" class="navbar__link">About</a>
-						<a href="/blogs.html" class="navbar__link">Blog</a>
+						<a href="blogs.html" class="navbar__link">Blog</a>
 					</nav>
 					<div class="header__actions">
 						<button class="button button__contact">Contact Us</button>
@@ -46,7 +46,7 @@
 						<div class="hamburger__menu">
 							<a href="index.html" class="hamburger__link">Home</a>
 							<a href="about.html" class="hamburger__link">About</a>
-							<a href="/blogs.html" class="hamburger__link">Blog</a>
+							<a href="blogs.html" class="hamburger__link">Blog</a>
 						</div>
 					</div>
 				</div>
@@ -376,7 +376,7 @@
 									<a href="about.html" class="footer__link">About</a>
 								</li>
 								<li class="footer__item">
-									<a href="#" class="footer__link">Blog</a>
+									<a href="blogs.html" class="footer__link">Blog</a>
 								</li>
 							</ul>
 						</div>


### PR DESCRIPTION
The blog links in the navigation and footer were using absolute paths, which could cause issues when deploying to different environments. Updated the links to use relative paths for consistency and reliability.